### PR TITLE
fix 404 errors when using React Router with Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
+# syntax=docker/dockerfile:1
 # Stage 1
 FROM node:20-alpine as builder
-WORKDIR /app
-COPY package.json .
-COPY package-lock.json .
-RUN npm install
+WORKDIR /home/node/app
 COPY . .
+RUN npm ci
 RUN npm run build
 
 # Stage 2
-FROM nginx:1.25-alpine
+FROM nginx:1.25-alpine as server
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
-COPY --from=builder /app/build .
+COPY --from=builder /home/node/app/build .
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen       80;
+    listen  [::]:80;
+
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
\https://www.frontendundefined.com/posts/tutorials/nginx-react-router-404/#:~:text=We%20need%20to%20instruct%20nginx,and%20will%20always%20serve%20index.